### PR TITLE
Fix I2C speed settings for consistency with other SoCs

### DIFF
--- a/drivers/i2c/nuc970_i2c.c
+++ b/drivers/i2c/nuc970_i2c.c
@@ -142,7 +142,8 @@ static int32_t _i2cSetSpeed(i2c_dev *dev, int32_t sp)
 
 	//if( sp != 100 && sp != 400)
 	//	return(I2C_ERR_NOTTY);
-
+	/* assume speed above 1000 are Hz-specified */
+        if(sp > 1000) sp = sp/1000;
 	if(sp > 400) sp = 400;
 
 	d = I2C_INPUT_CLOCK/(sp * 5) -1;

--- a/drivers/i2c/nuc970_i2c.c
+++ b/drivers/i2c/nuc970_i2c.c
@@ -750,7 +750,7 @@ static int  nuc970_i2c_read(struct i2c_adapter *adap, uchar chip, uint addr,
 
 	for(i = 0 ; i < len; i++)
 	{
-		i2cIoctl(I2CNUM, I2C_IOC_SET_SUB_ADDRESS, addr+i, 2);
+		i2cIoctl(I2CNUM, I2C_IOC_SET_SUB_ADDRESS, addr+i, alen);
 		j = RETRY;
 		while(j-- > 0)
 		{
@@ -782,7 +782,7 @@ static int  nuc970_i2c_write(struct i2c_adapter *adap, uchar chip, uint addr,
 	//printf("Start Tx --> %d %d \n", len, alen);
 	for(i = 0 ; i < len ; i++)
 	{
-		i2cIoctl(I2CNUM, I2C_IOC_SET_SUB_ADDRESS, addr+i, 2);
+		i2cIoctl(I2CNUM, I2C_IOC_SET_SUB_ADDRESS, addr+i, alen);
 		j = RETRY;
 		while(j-- > 0)
 		{


### PR DESCRIPTION
Allow I2C speed to be specified in both Hz (as defined by U-Boot) and kHz (as was before)