### PR TITLE
Support EMAC0 without MDC connection (for switch)

### DIFF
--- a/board/nuvoton/nuc970/nuc970.c
+++ b/board/nuvoton/nuc970/nuc970.c
@@ -110,7 +110,11 @@ int board_eth_init(bd_t *bis)
     writel(readl(REG_HCLKEN) | 0x10000, REG_HCLKEN);   // EMAC0 clk
     writel(readl(REG_CLKDIVCTL8) | 0x10, REG_CLKDIVCTL8); //MII management interface clock
     //Init multi-function pin for RMII
+#ifdef CONFIG_NUC970_EMAC0_NO_MDC
+    writel(0x11111100, REG_MFP_GPF_L);	// pin F2~F7 for RMII0, F0~F1 stay GPIO
+#else
     writel(0x11111111, REG_MFP_GPF_L);	// pin F0~F7 for RMII0
+#endif /* CONFIG_NUC970_EMAC0_NO_MDC */
     writel((readl(REG_MFP_GPF_H) & ~0xff) | 0x11, REG_MFP_GPF_H);// pin F8~F9 for RMII0
 #else //CONFIG_NUC970_EMAC1
     writel(readl(REG_HCLKEN) | 0x20000, REG_HCLKEN);   // EMAC1 clk

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -225,6 +225,12 @@ config NUC970_EMAC0
 	help
 	  Select this to use EMAC0 otherwsie EMAC1
 
+config NUC970_EMAC0_NO_MDC
+	bool "NUC970/N9H30 EMAC0 without MDC bus support"
+	depends on NUC970_EMAC0
+	help
+	  Select this to not use EMAC0 MDC interface (like if you have switch, directly connected to RMII)
+	  
 config NUC970_PHY_ADDR
 	int "PHY Address"
 	depends on NUC970_ETH

--- a/drivers/net/nuc970_eth.c
+++ b/drivers/net/nuc970_eth.c
@@ -44,7 +44,7 @@ int nuc970_reset_phy(void)
 	writel(readl(MCMDR) | MCMDR_OPMOD | MCMDR_FDUP, MCMDR);
 	return(0);
 }
-#else
+#else /* CONFIG_NUC970_EMAC0_NO_MDC */
 int nuc970_eth_mii_write(uchar addr, uchar reg, ushort val)
 {
 

--- a/drivers/net/nuc970_eth.c
+++ b/drivers/net/nuc970_eth.c
@@ -37,7 +37,14 @@ struct eth_descriptor volatile tx_desc[TX_DESCRIPTOR_NUM] __attribute__ ((aligne
 
 struct eth_descriptor volatile *tx_desc_ptr, *rx_desc_ptr;
 
-
+#ifdef CONFIG_NUC970_EMAC0_NO_MDC
+int nuc970_reset_phy(void)
+{
+	/* Just set EMAC to 100Mb Full-duplex */
+	writel(readl(MCMDR) | MCMDR_OPMOD | MCMDR_FDUP, MCMDR);
+	return(0);
+}
+#else
 int nuc970_eth_mii_write(uchar addr, uchar reg, ushort val)
 {
 
@@ -117,7 +124,7 @@ int nuc970_reset_phy(void)
 
         return(0);
 }
-
+#endif /* CONFIG_NUC970_EMAC0_NO_MDC */
 
 void init_tx_desc(void)
 {

--- a/drivers/serial/serial_nuc970.c
+++ b/drivers/serial/serial_nuc970.c
@@ -23,7 +23,7 @@
  */
 #include <common.h>
 #include <asm/io.h>
-
+#include <watchdog.h>
 #include <serial.h>
 
 //#include "serial_nuc970.h"
@@ -161,6 +161,7 @@ int nuc970_serial_getc (void)
 		{
 			return (UART0->x.RBR);
 		}
+		WATCHDOG_RESET();
 	}
 }
 #endif

--- a/drivers/spi/nuc970_spi.c
+++ b/drivers/spi/nuc970_spi.c
@@ -104,6 +104,7 @@ int spi_claim_bus(struct spi_slave *slave)
 	writel(readl(REG_MFP_GPB_H) | 0xBBBB0000, REG_MFP_GPB_H);
 #endif
 
+#ifdef CONFIG_NUC970_SPI_Quad
 	//cp = getenv("spimode");
 	if (1) { //(cp) {
 		if (1) { //(*cp == SPI_QUAD_MODE ) {
@@ -116,7 +117,7 @@ int spi_claim_bus(struct spi_slave *slave)
 #endif
 		}
 	}
-
+#endif /* CONFIG_NUC970_SPI_Quad */
 	writel(SPI_8BIT, SPICTL);
 
 	if(ns->mode & SPI_CS_HIGH)
@@ -159,6 +160,7 @@ void spi_release_bus(struct spi_slave *slave)
 	writel(readl(REG_MFP_GPB_H) & ~0xBBBB0000, REG_MFP_GPB_H);
 #endif
 
+#ifdef CONFIG_NUC970_SPI_Quad
 	//cp = getenv("spimode");
 	if (1) { //(cp) {
 		if (1) { //(*cp == SPI_QUAD_MODE ) {
@@ -171,6 +173,7 @@ void spi_release_bus(struct spi_slave *slave)
 #endif
 		}
 	}
+#endif /* CONFIG_NUC970_SPI_Quad */	
 }
 
 int spi_xfer(struct spi_slave *slave, unsigned int bitlen,


### PR DESCRIPTION
CONFIG_NUC970_EMAC0_NO_MDC=y does 3 things:
1) pins PF.0 and PF.1 (usually used for MDC/MDIO) stays in it's default state
2) PHY setup manipulations skipped
3) EMAC0 always forced to 100Mb FDX operation
